### PR TITLE
Make location more neutral

### DIFF
--- a/config_default.php
+++ b/config_default.php
@@ -100,7 +100,7 @@ $config['cops_show_icons'] = '1';
  * Check following link for other timezones :
  * http://www.php.net/manual/en/timezones.php
  */
-$config['default_timezone'] = 'Europe/Paris';
+$config['default_timezone'] = 'UTC';
 
 /*
  * Prefered format for HTML catalog

--- a/epubreader.php
+++ b/epubreader.php
@@ -1,7 +1,7 @@
 <?php
 header('Content-Type: text/html;charset=utf-8');
 ?><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="fr" lang="fr">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="und" lang="">
 <?php
 /**
  * COPS (Calibre OPDS PHP Server) epub reader


### PR DESCRIPTION
COPS was originally written by a french speaker, so some of the code is specific to this context. I've made a couple of small changes to make it more neutral.

1. Set default Timezone from Europe/Paris to UTC
2. Change the web epub reader to specify the language as undetermined - hard coding this to French was triggering translation plugins in browsers when it wasn't necessarily needed.