### PR TITLE
Revert to default template

### DIFF
--- a/config_default.php
+++ b/config_default.php
@@ -100,7 +100,7 @@ $config['cops_show_icons'] = '1';
  * Check following link for other timezones :
  * http://www.php.net/manual/en/timezones.php
  */
-$config['default_timezone'] = 'Europe/Paris';
+$config['default_timezone'] = 'UTC';
 
 /*
  * Prefered format for HTML catalog

--- a/config_default.php
+++ b/config_default.php
@@ -327,7 +327,7 @@ $config['cops_basic_authentication'] = null;
  * 'bootstrap'
  * 'bootstrap2'
  */
-$config['cops_template'] = 'bootstrap2';
+$config['cops_template'] = 'default';
 
 /*
  * Which style is used by default :

--- a/epubreader.php
+++ b/epubreader.php
@@ -1,7 +1,7 @@
 <?php
 header('Content-Type: text/html;charset=utf-8');
 ?><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="fr" lang="fr">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="und" lang="">
 <?php
 /**
  * COPS (Calibre OPDS PHP Server) epub reader


### PR DESCRIPTION
I use a Kindle Paperwhite and would like to be able to download MOBI and AZW3 files directly from COPS to it.  This is not currently possible with Bootstrap2 template. 

While the initial page listing categories (Authors, Recent books etc.) displays fine, the pages listing books does not work for some reason.  

Unfortunately it is also not possible to switch into the default template using the link at the top of the page - for some reason the Kindle Paperwhite does not update the cookie and refresh the page, as the Javascript onclick event for the link should do. 

For now the only way I have managed to access the COPS library from my Kindle Paperwhite is to set the template to default. Once I have done that I am able to change the template from default to bootstrap2 (and bootstrap) but not back. It's a real headscratcher.