### PR TITLE
Replace offering to email MOBI with EPub

### DIFF
--- a/lib/Book.php
+++ b/lib/Book.php
@@ -374,7 +374,7 @@ class Book extends Base
 
     public function GetMostInterestingDataToSendToKindle()
     {
-        $bestFormatForKindle = ['EPUB', 'PDF', 'AZW3', 'MOBI'];
+        $bestFormatForKindle = ['EPUB', 'PDF', 'AZW3'];
         $bestRank = -1;
         $bestData = null;
         foreach ($this->getDatas() as $data) {


### PR DESCRIPTION
Amazon are soon to stop accepting MOBI files for conversion and sending to Kindle in favour of ePub. 

This may not be the best way to enable sending ePub's, especially for people that want to send MOBI somewhere other than Amazon.  However, I couldn't figure out how to enable ePub's at all if MOBI files already exist. Is there a way of allowing sending all formats?