### PR TITLE
Improve email

### DIFF
--- a/base.php
+++ b/base.php
@@ -101,7 +101,7 @@ function getCurrentOption($option)
     if (isset($_COOKIE[$option])) {
         if (isset($config ['cops_' . $option]) && is_array($config ['cops_' . $option])) {
             return explode(',', $_COOKIE[$option]);
-        } elseif (!preg_match('/[^A-Za-z0-9\-_]/', $_COOKIE[$option])) {
+        } elseif (!preg_match('/[^A-Za-z0-9\-_.@]/', $_COOKIE[$option])) {
             return $_COOKIE[$option];
         }
     }

--- a/sendtomail.php
+++ b/sendtomail.php
@@ -82,22 +82,12 @@ if (!empty($config['cops_mail_configuration']["smtp.port"])) {
 $mail->From = $config['cops_mail_configuration']["address.from"];
 $mail->FromName = $config['cops_title_default'];
 
-# Limit sending to 5 email addresses
-$emailAddresses = explode(";", $emailDest);
-if(count($emailAddresses) <= 5){
-    foreach ($emailAddresses as $emailAddress) {
-        if (empty($emailAddress)) {
-            continue;
-        }
-        if (!filter_var($emailAddress, FILTER_VALIDATE_EMAIL)) {
-            echo  $emailAddress . " is an unsupported email address. Update the email address on the settings page.";
-            exit;
-        }
-        $mail->AddAddress($emailAddress);
-    }
-} else {
-    echo "You can send to a maximum of 5 email addresses. Please update your email address list.";
+# Validate emailDest
+if (!filter_var($emailDest, FILTER_VALIDATE_EMAIL)) {
+    echo  $emailAddress . " is an unsupported email address. Update the email address on the settings page.";
     exit;
+} else {
+    $mail->AddAddress($emailAddress);
 }
 
 $mail->AddAttachment($data->getLocalPath());

--- a/sendtomail.php
+++ b/sendtomail.php
@@ -82,11 +82,22 @@ if (!empty($config['cops_mail_configuration']["smtp.port"])) {
 $mail->From = $config['cops_mail_configuration']["address.from"];
 $mail->FromName = $config['cops_title_default'];
 
-foreach (explode(";", $emailDest) as $emailAddress) {
-    if (empty($emailAddress)) {
-        continue;
+# Limit sending to 5 email addresses
+$emailAddresses = explode(";", $emailDest);
+if(count($emailAddresses) <= 5){
+    foreach ($emailAddresses as $emailAddress) {
+        if (empty($emailAddress)) {
+            continue;
+        }
+        if (!filter_var($emailAddress, FILTER_VALIDATE_EMAIL)) {
+            echo  $emailAddress . " is an unsupported email address. Update the email address on the settings page.";
+            exit;
+        }
+        $mail->AddAddress($emailAddress);
     }
-    $mail->AddAddress($emailAddress);
+} else {
+    echo "You can send to a maximum of 5 email addresses. Please update your email address list.";
+    exit;
 }
 
 $mail->AddAttachment($data->getLocalPath());

--- a/sendtomail.php
+++ b/sendtomail.php
@@ -84,10 +84,10 @@ $mail->FromName = $config['cops_title_default'];
 
 # Validate emailDest
 if (!filter_var($emailDest, FILTER_VALIDATE_EMAIL)) {
-    echo  $emailAddress . " is an unsupported email address. Update the email address on the settings page.";
+    echo  $emailDest . " is an unsupported email address. Update the email address on the settings page.";
     exit;
 } else {
-    $mail->AddAddress($emailAddress);
+    $mail->AddAddress($emailDest);
 }
 
 $mail->AddAttachment($data->getLocalPath());


### PR DESCRIPTION
Limit sending to a single email address which must be valid. (Previously the code exploded a list of email addresses delimited with `;`, however the cookie extraction code didn't allow that character, and there really is no good reason to allow sending to more than one address in one step.

Fix bug that prevented configured email address from being displayed on customisation page.