### PR TITLE
Fixes to Bootstrap5 to work server side

### DIFF
--- a/templates/bootstrap5/header.html
+++ b/templates/bootstrap5/header.html
@@ -30,6 +30,10 @@
           </li>
         </ul>
         <form id="searchForm" class="d-flex ps-2" role="search" action="index.php" method="get">
+            <input type="hidden" name="page" value="9">
+            {{? it.databaseId != ""}}
+                        <input type="hidden" name="db" value="{{=it.databaseId}}">
+            {{?}}
             <input id="queryInput" name="query" class="form-control form-control-sm me-2" type="text" placeholder="{{=it.c.i18n.searchAlt}}" aria-label="{{=it.c.i18n.searchAlt}}">
             <button class="btn btn-sm btn-outline-primary" type="submit">Search</button>
         </form>

--- a/templates/bootstrap5/header.html
+++ b/templates/bootstrap5/header.html
@@ -29,7 +29,7 @@
             <a class="nav-link{{? it.page == 4}} active{{?}}" href="index.php?page=4"{{? it.page ==4 }} aria-current="page"{{?}}>{{=it.c.i18n.allbooksTitle}}</a>
           </li>
         </ul>
-        <form id="searchForm" class="d-flex ps-2" role="search">
+        <form id="searchForm" class="d-flex ps-2" role="search" action="index.php" method="get">
             <input id="queryInput" name="query" class="form-control form-control-sm me-2" type="text" placeholder="{{=it.c.i18n.searchAlt}}" aria-label="{{=it.c.i18n.searchAlt}}">
             <button class="btn btn-sm btn-outline-primary" type="submit">Search</button>
         </form>

--- a/templates/bootstrap5/header.html
+++ b/templates/bootstrap5/header.html
@@ -32,9 +32,9 @@
         <form id="searchForm" class="d-flex ps-2" role="search" action="index.php" method="get">
             <input type="hidden" name="page" value="9">
             {{? it.databaseId != ""}}
-                        <input type="hidden" name="db" value="{{=it.databaseId}}">
+              <input type="hidden" name="db" value="{{=it.databaseId}}">
             {{?}}
-            <input id="queryInput" name="query" class="form-control form-control-sm me-2" type="text" placeholder="{{=it.c.i18n.searchAlt}}" aria-label="{{=it.c.i18n.searchAlt}}">
+            <input id="queryInput" name="query" class="form-control form-control-sm me-2" type="text" placeholder="{{=it.c.i18n.searchAlt}}" aria-label="{{=it.c.i18n.searchAlt}}" data-type="search" required="required">
             <button class="btn btn-sm btn-outline-primary" type="submit">Search</button>
         </form>
       </div>

--- a/templates/bootstrap5/main.html
+++ b/templates/bootstrap5/main.html
@@ -32,7 +32,7 @@
     <!-- end Not book data -->
 {{??}}
 <div class="row row-cols-2 row-cols-md-5 g-0">
-    {{~it.entries:entry:i}}
+    {{~it.entries:entry:idx}}
         <div class="card">
             <div class="cover-image">
                 {{? entry.book.hasCover == 1}}
@@ -44,17 +44,19 @@
             <div class="card-body meta">
                 <h5 class="card-title title text-truncate"><a href="{{=str_format (it.c.url.detailUrl, entry.book.id, it.databaseId)}}#cover">{{=htmlspecialchars (entry.title)}}</a></h5>
                 <div class="card-subtitle author text-truncate">
-                    {{~ entry.book.authors:author:author_index}}{{? author_index > 0}}, {{?}}<a href="{{=author.url}}">{{=htmlspecialchars (author.name)}}</a>{{~}}
+                    {{~ entry.book.authors:author:i}}{{? i != 0 }}, {{?}}<a href="{{=author.url}}">{{=htmlspecialchars (author.name)}}</a>{{~}}
                 </div>
-                {{? entry.book.seriesName != ""}}<div class="series text-truncate"><a href="{{=entry.book.seriesurl}}">{{=htmlspecialchars (entry.book.seriesName)}}</a> ({{=entry.book.seriesIndex}})</div>{{?}}
+                {{? entry.book.seriesName != ""}}
+                <div class="series text-truncate"><a href="{{=entry.book.seriesurl}}">{{=htmlspecialchars (entry.book.seriesName)}}</a> ({{=entry.book.seriesIndex}})</div>
+                {{?}}
                 <!-- custom columns not tested -->
-                {{~entry.book.customcolumns_list :column:column_index}}
+                {{~ entry.book.customcolumns_list:column:column_index}}
                 <div class="text-truncate"><i class="bi-node-minus pe-1"></i><span class="ss">{{=column.customColumnType.columnTitle}} : {{=column.htmlvalue}}</span></div>
                 {{~}}
             </div>
             <div class="card-footer">
                 <!-- download buttons for each available format -->
-                    {{~entry.book.preferedData:data:j}}
+                    {{~ entry.book.preferedData:data:i}}
                     <a href="{{=data.url}}" class="btn btn-primary btn-sm" role="button">{{=data.name}}</a>
                     {{~}}
             </div>


### PR DESCRIPTION
I made some changes to my template to get it working server side.

Not only have I sorted out the nested iterations - thanks @mikespub  - but also got the Search form working server side.  The form needs the `action="index.php"` and `method="get"` attributes, and the hidden input to set the search results page, plus another hidden field specifying the database if this is set.
```
<input type="hidden" name="page" value="9">
            {{? it.databaseId != ""}}
              <input type="hidden" name="db" value="{{=it.databaseId}}">
            {{?}}
```
The typeahead search still works client side, but the above means return or submit button work on server side clients.

For some reason, this was missing from all the bootstrap templates, which is why search only worked on kindle with the default template.