### PR TITLE
Bootstrap5 sort toggle

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -159,16 +159,16 @@
         },
         {
             "name": "npm-asset/babel--runtime",
-            "version": "v7.22.17",
+            "version": "v7.22.19",
             "source": {
                 "type": "git",
                 "url": "https://github.com/babel/babel.git",
-                "reference": "49adb6008120607adb559fd21e8f5a6df7b1a492"
+                "reference": "77b0d7359909c94f3797c24006f244847fbc8d6d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/babel/babel/zipball/49adb6008120607adb559fd21e8f5a6df7b1a492",
-                "reference": "49adb6008120607adb559fd21e8f5a6df7b1a492"
+                "url": "https://api.github.com/repos/babel/babel/zipball/77b0d7359909c94f3797c24006f244847fbc8d6d",
+                "reference": "77b0d7359909c94f3797c24006f244847fbc8d6d"
             },
             "type": "npm-asset"
         },
@@ -1282,16 +1282,16 @@
         },
         {
             "name": "mikespub/epub-loader",
-            "version": "2.1.1",
+            "version": "2.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mikespub-org/epub-loader.git",
-                "reference": "81b4a0a34f5a16252a9abcb5c4944c1795c298e3"
+                "reference": "a8dbaaf1020a37117e658a756a22c723dcb40d29"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mikespub-org/epub-loader/zipball/81b4a0a34f5a16252a9abcb5c4944c1795c298e3",
-                "reference": "81b4a0a34f5a16252a9abcb5c4944c1795c298e3",
+                "url": "https://api.github.com/repos/mikespub-org/epub-loader/zipball/a8dbaaf1020a37117e658a756a22c723dcb40d29",
+                "reference": "a8dbaaf1020a37117e658a756a22c723dcb40d29",
                 "shasum": ""
             },
             "require": {
@@ -1329,9 +1329,9 @@
             "description": "epub-loader is a utility resource for ebooks",
             "support": {
                 "issues": "https://github.com/mikespub-org/epub-loader/issues",
-                "source": "https://github.com/mikespub-org/epub-loader/tree/2.1.1"
+                "source": "https://github.com/mikespub-org/epub-loader/tree/2.1.2"
             },
-            "time": "2023-09-11T20:05:10+00:00"
+            "time": "2023-09-16T11:15:33+00:00"
         },
         {
             "name": "myclabs/deep-copy",

--- a/templates/bootstrap5/footer.html
+++ b/templates/bootstrap5/footer.html
@@ -1,4 +1,3 @@
-<!-- put footer directly after header so that on browsers that don't support fixed-bottom, all the controls are at the top of the page -->
 <footer class="fixed-bottom" style="font-size: 0.8rem;">
     <ul class="nav nav-pills bg-body-tertiary justify-content-end" data-bs-theme="dark">
         <li class="nav-item">

--- a/templates/bootstrap5/footer.html
+++ b/templates/bootstrap5/footer.html
@@ -1,0 +1,20 @@
+<!-- put footer directly after header so that on browsers that don't support fixed-bottom, all the controls are at the top of the page -->
+<footer class="fixed-bottom" style="font-size: 0.8rem;">
+    <ul class="nav nav-pills bg-body-tertiary justify-content-end" data-bs-theme="dark">
+        <li class="nav-item">
+          <a class="nav-link" href="#" onclick='Cookies.set("template", "default", { expires: 365 }); window.location.reload(true); ' data-toggle="tooltip" data-placement="bottom" title="" data-original-title="{{=it.c.i18n.defaultTemplate}}">
+          <i class="bi-escape pe-1"></i> {{=it.c.i18n.defaultTemplate}}</span>
+        </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link{{? it.page == 19}} active{{?}}" href="{{=it.customizeurl}}" data-toggle="tooltip" data-placement="bottom" title="" data-original-title="{{=it.c.i18n.customizeTitle}}">
+            <i class="bi-tools pe-1"></i>{{=it.c.i18n.customizeTitle}}
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link{{? it.page == 16}} active{{?}}" href="{{=it.abouturl}}" data-toggle="tooltip" data-placement="bottom" title="" data-original-title="{{=it.c.i18n.aboutTitle}}">
+            <i class="bi-info-circle pe-1"></i>{{=it.c.i18n.aboutTitle}}
+            </a>
+        </li>
+      </ul>
+  </footer>

--- a/templates/bootstrap5/header.html
+++ b/templates/bootstrap5/header.html
@@ -52,19 +52,19 @@
         <li class="nav-item p-1 border-start border-secondary-subtle">Sort by:</li>
         {{? it.sortoptions.title }}
         <li class="nav-item sm">
-          <a class="nav-link p-1{{? it.sorted == "title" && it.c.config.server_side_rendering == 0 }} active{{?}}"
-          {{? it.sorted == "title"}}
+          <a class="nav-link p-1{{? it.sorted == "title" }} active{{?}}"
+          {{? it.sorted == "title" && it.c.config.server_side_rendering == 0 }}
           onclick="reverseSortEntries()" href="#"
           {{??}}
           href="{{=str_format(it.sorturl, "title")}}"
           {{?}}
           ><i class="bi-sort-alpha-down"></i>Title</a>
         </li>
-        {{?}}
-        {{? it.sortoptions.author }}
-        <li class="nav-item sm">
+          {{?}}
+          {{? it.sortoptions.author }}
+          <li class="nav-item sm">
           <a class="nav-link p-1{{? it.sorted == "author" }} active{{?}}"
-          {{? it.sorted == "author"}}
+          {{? it.sorted == "author" && it.c.config.server_side_rendering == 0 }}
           onclick="reverseSortEntries()" href="#"
           {{??}}
           href="{{=str_format(it.sorturl, "author")}}"
@@ -74,8 +74,8 @@
         {{?}}
         {{? it.sortoptions.pubdate }}
         <li class="nav-item sm">
-          <a class="nav-link p-1{{? it.sorted == "pubdate" && it.c.config.server_side_rendering == 0 }} active{{?}}"
-          {{? it.sorted == "pubdate"}}
+          <a class="nav-link p-1{{? it.sorted == "pubdate" }} active{{?}}"
+          {{? it.sorted == "pubdate" && it.c.config.server_side_rendering == 0 }}
           onclick="reverseSortEntries()" href="#"
           {{??}}
           href="{{=str_format(it.sorturl, "pubdate")}}"
@@ -85,8 +85,8 @@
         {{?}}
         {{? it.sortoptions.rating }}
         <li class="nav-item sm">
-          <a class="nav-link p-1{{? it.sorted == "rating" && it.c.config.server_side_rendering == 0 }} active{{?}}"
-          {{? it.sorted == "rating"}}
+          <a class="nav-link p-1{{? it.sorted == "rating" }} active{{?}}"
+          {{? it.sorted == "rating" && it.c.config.server_side_rendering == 0 }}
           onclick="reverseSortEntries()" href="#"
           {{??}}
           href="{{=str_format(it.sorturl, "rating")}}"
@@ -96,8 +96,8 @@
         {{?}}
         {{? it.sortoptions.timestamp || it.sorted == "timestamp desc" }}
         <li class="nav-item sm">
-          <a class="nav-link p-1{{? (it.sorted == "timestamp" || it.sorted == "timestamp desc") && it.c.config.server_side_rendering == 0 }} active{{?}}"
-          {{? it.sorted == "timestamp"}}
+          <a class="nav-link p-1{{? (it.sorted == "timestamp" || it.sorted == "timestamp desc") }} active{{?}}"
+          {{? (it.sorted == "timestamp" || it.sorted == "timestamp desc") && it.c.config.server_side_rendering == 0}}
           onclick="reverseSortEntries()" href="#"
           {{??}}
           href="{{=str_format(it.sorturl, "timestamp")}}"

--- a/templates/bootstrap5/header.html
+++ b/templates/bootstrap5/header.html
@@ -61,7 +61,7 @@
           ><i class="bi-sort-alpha-down"></i>Title</a>
         </li>
         {{?}}
-        {{? it.sortoptions.author }}
+        {{? it.sortoptions.author && it.c.config.server_side_rendering == 0 }}
         <li class="nav-item sm">
           <a class="nav-link p-1{{? it.sorted == "author" }} active{{?}}"
           {{? it.sorted == "author"}}
@@ -72,7 +72,7 @@
           ><i class="bi-sort-alpha-down"></i>Author</a>
         </li>
         {{?}}
-        {{? it.sortoptions.pubdate }}
+        {{? it.sortoptions.pubdate && it.c.config.server_side_rendering == 0 }}
         <li class="nav-item sm">
           <a class="nav-link p-1{{? it.sorted == "pubdate" }} active{{?}}"
           {{? it.sorted == "pubdate"}}
@@ -83,7 +83,7 @@
           ><i class="bi-sort-numeric-down"></i>Published</a>
         </li>
         {{?}}
-        {{? it.sortoptions.rating }}
+        {{? it.sortoptions.rating && it.c.config.server_side_rendering == 0 }}
         <li class="nav-item sm">
           <a class="nav-link p-1{{? it.sorted == "rating" }} active{{?}}"
           {{? it.sorted == "rating"}}
@@ -95,7 +95,7 @@
           <i class="bi-sort-numeric-up"></i>Rating</a>
         </li>
         {{?}}
-        {{? it.sortoptions.timestamp }}
+        {{? it.sortoptions.timestamp && it.c.config.server_side_rendering == 0 }}
         <li class="nav-item sm">
           <a class="nav-link p-1{{? it.sorted == "timestamp" || it.sorted == "timestamp desc" }} active{{?}}"
           {{? it.sorted == "timestamp"}}

--- a/templates/bootstrap5/header.html
+++ b/templates/bootstrap5/header.html
@@ -117,23 +117,3 @@
     </nav>
   {{?}}
 </header>
-<!-- put footer directly after header so that on browsers that don't support fixed-bottom, all the controls are at the top of the page -->
-<footer class="fixed-bottom" style="font-size: 0.8rem;">
-  <ul class="nav nav-pills bg-body-tertiary justify-content-end" data-bs-theme="dark">
-      <li class="nav-item">
-        <a class="nav-link" href="#" onclick='Cookies.set("template", "default", { expires: 365 }); window.location.reload(true); ' data-toggle="tooltip" data-placement="bottom" title="" data-original-title="{{=it.c.i18n.defaultTemplate}}">
-        <i class="bi-escape pe-1"></i> {{=it.c.i18n.defaultTemplate}}</span>
-      </a>
-      </li>
-      <li class="nav-item">
-          <a class="nav-link{{? it.page == 19}} active{{?}}" href="{{=it.customizeurl}}" data-toggle="tooltip" data-placement="bottom" title="" data-original-title="{{=it.c.i18n.customizeTitle}}">
-          <i class="bi-tools pe-1"></i>{{=it.c.i18n.customizeTitle}}
-          </a>
-      </li>
-      <li class="nav-item">
-          <a class="nav-link{{? it.page == 16}} active{{?}}" href="{{=it.abouturl}}" data-toggle="tooltip" data-placement="bottom" title="" data-original-title="{{=it.c.i18n.aboutTitle}}">
-          <i class="bi-info-circle pe-1"></i>{{=it.c.i18n.aboutTitle}}
-          </a>
-      </li>
-    </ul>
-</footer>

--- a/templates/bootstrap5/header.html
+++ b/templates/bootstrap5/header.html
@@ -52,7 +52,7 @@
         <li class="nav-item p-1 border-start border-secondary-subtle">Sort by:</li>
         {{? it.sortoptions.title }}
         <li class="nav-item sm">
-          <a class="nav-link p-1{{? it.sorted == "title" }} active{{?}}"
+          <a class="nav-link p-1{{? it.sorted == "title" && it.c.config.server_side_rendering == 0 }} active{{?}}"
           {{? it.sorted == "title"}}
           onclick="reverseSortEntries()" href="#"
           {{??}}
@@ -61,7 +61,7 @@
           ><i class="bi-sort-alpha-down"></i>Title</a>
         </li>
         {{?}}
-        {{? it.sortoptions.author && it.c.config.server_side_rendering == 0 }}
+        {{? it.sortoptions.author }}
         <li class="nav-item sm">
           <a class="nav-link p-1{{? it.sorted == "author" }} active{{?}}"
           {{? it.sorted == "author"}}
@@ -72,9 +72,9 @@
           ><i class="bi-sort-alpha-down"></i>Author</a>
         </li>
         {{?}}
-        {{? it.sortoptions.pubdate && it.c.config.server_side_rendering == 0 }}
+        {{? it.sortoptions.pubdate }}
         <li class="nav-item sm">
-          <a class="nav-link p-1{{? it.sorted == "pubdate" }} active{{?}}"
+          <a class="nav-link p-1{{? it.sorted == "pubdate" && it.c.config.server_side_rendering == 0 }} active{{?}}"
           {{? it.sorted == "pubdate"}}
           onclick="reverseSortEntries()" href="#"
           {{??}}
@@ -83,28 +83,26 @@
           ><i class="bi-sort-numeric-down"></i>Published</a>
         </li>
         {{?}}
-        {{? it.sortoptions.rating && it.c.config.server_side_rendering == 0 }}
+        {{? it.sortoptions.rating }}
         <li class="nav-item sm">
-          <a class="nav-link p-1{{? it.sorted == "rating" }} active{{?}}"
+          <a class="nav-link p-1{{? it.sorted == "rating" && it.c.config.server_side_rendering == 0 }} active{{?}}"
           {{? it.sorted == "rating"}}
           onclick="reverseSortEntries()" href="#"
           {{??}}
           href="{{=str_format(it.sorturl, "rating")}}"
           {{?}}
-          >
-          <i class="bi-sort-numeric-up"></i>Rating</a>
+          ><i class="bi-sort-numeric-up"></i>Rating</a>
         </li>
         {{?}}
-        {{? it.sortoptions.timestamp && it.c.config.server_side_rendering == 0 }}
+        {{? it.sortoptions.timestamp || it.sorted == "timestamp desc" }}
         <li class="nav-item sm">
-          <a class="nav-link p-1{{? it.sorted == "timestamp" || it.sorted == "timestamp desc" }} active{{?}}"
+          <a class="nav-link p-1{{? (it.sorted == "timestamp" || it.sorted == "timestamp desc") && it.c.config.server_side_rendering == 0 }} active{{?}}"
           {{? it.sorted == "timestamp"}}
           onclick="reverseSortEntries()" href="#"
           {{??}}
           href="{{=str_format(it.sorturl, "timestamp")}}"
           {{?}}
-          >
-          <i class="bi-sort-numeric-up"></i>Added</a>
+          ><i class="bi-sort-numeric-up"></i>Added</a>
         </li>
         {{?}}
         {{?}}

--- a/templates/bootstrap5/header.html
+++ b/templates/bootstrap5/header.html
@@ -52,27 +52,59 @@
         <li class="nav-item p-1 border-start border-secondary-subtle">Sort by:</li>
         {{? it.sortoptions.title }}
         <li class="nav-item sm">
-          <a class="nav-link p-1{{? it.sorted == "title" }} active{{?}}" href="{{=str_format(it.sorturl, "title")}}"><i class="bi-sort-alpha-down"></i>Title</a>
+          <a class="nav-link p-1{{? it.sorted == "title" }} active{{?}}"
+          {{? it.sorted == "title"}}
+          onclick="reverseSortEntries()" href="#"
+          {{??}}
+          href="{{=str_format(it.sorturl, "title")}}"
+          {{?}}
+          ><i class="bi-sort-alpha-down"></i>Title</a>
         </li>
         {{?}}
         {{? it.sortoptions.author }}
         <li class="nav-item sm">
-          <a class="nav-link p-1{{? it.sorted == "author" }} active{{?}}" href="{{=str_format(it.sorturl, "author")}}"><i class="bi-sort-alpha-down"></i>Author</a>
+          <a class="nav-link p-1{{? it.sorted == "author" }} active{{?}}"
+          {{? it.sorted == "author"}}
+          onclick="reverseSortEntries()" href="#"
+          {{??}}
+          href="{{=str_format(it.sorturl, "author")}}"
+          {{?}}
+          ><i class="bi-sort-alpha-down"></i>Author</a>
         </li>
         {{?}}
         {{? it.sortoptions.pubdate }}
         <li class="nav-item sm">
-          <a class="nav-link p-1{{? it.sorted == "pubdate" }} active{{?}}" href="{{=str_format(it.sorturl, "pubdate")}}"><i class="bi-sort-numeric-down"></i>Published</a>
+          <a class="nav-link p-1{{? it.sorted == "pubdate" }} active{{?}}"
+          {{? it.sorted == "pubdate"}}
+          onclick="reverseSortEntries()" href="#"
+          {{??}}
+          href="{{=str_format(it.sorturl, "pubdate")}}"
+          {{?}}
+          ><i class="bi-sort-numeric-down"></i>Published</a>
         </li>
         {{?}}
         {{? it.sortoptions.rating }}
         <li class="nav-item sm">
-          <a class="nav-link p-1{{? it.sorted == "rating" }} active{{?}}" href="{{=str_format(it.sorturl, "rating")}}"><i class="bi-sort-numeric-up"></i>Rating</a>
+          <a class="nav-link p-1{{? it.sorted == "rating" }} active{{?}}"
+          {{? it.sorted == "rating"}}
+          onclick="reverseSortEntries()" href="#"
+          {{??}}
+          href="{{=str_format(it.sorturl, "rating")}}"
+          {{?}}
+          >
+          <i class="bi-sort-numeric-up"></i>Rating</a>
         </li>
         {{?}}
         {{? it.sortoptions.timestamp }}
         <li class="nav-item sm">
-          <a class="nav-link p-1{{? it.sorted == "timestamp" || it.sorted == "timestamp desc" }} active{{?}}" href="{{=str_format(it.sorturl, "timestamp" ) }}"><i class="bi-sort-numeric-up"></i>Added</a>
+          <a class="nav-link p-1{{? it.sorted == "timestamp" || it.sorted == "timestamp desc" }} active{{?}}"
+          {{? it.sorted == "timestamp"}}
+          onclick="reverseSortEntries()" href="#"
+          {{??}}
+          href="{{=str_format(it.sorturl, "timestamp")}}"
+          {{?}}
+          >
+          </i>Added</a>
         </li>
         {{?}}
         {{?}}

--- a/templates/bootstrap5/header.html
+++ b/templates/bootstrap5/header.html
@@ -104,7 +104,7 @@
           href="{{=str_format(it.sorturl, "timestamp")}}"
           {{?}}
           >
-          </i>Added</a>
+          <i class="bi-sort-numeric-up"></i>Added</a>
         </li>
         {{?}}
         {{?}}

--- a/templates/bootstrap5/main.html
+++ b/templates/bootstrap5/main.html
@@ -1,7 +1,8 @@
-<div class="container-fluid p-1" id="main">
 {{? it.page == 13 || it.page == 16}}
     {{? it.page == 13}}
+        <div id="bookdetail">
         {{#def.bookdetail}}
+        </div>
     {{??}}
         {{= it.fullhtml}}
     {{?}}
@@ -74,4 +75,3 @@
     </ul>
 </nav>
 {{?}}
-</div>

--- a/templates/bootstrap5/main.html
+++ b/templates/bootstrap5/main.html
@@ -1,4 +1,4 @@
-<div class="container-fluid p-1">
+<div class="container-fluid p-1" id="main">
 {{? it.page == 13 || it.page == 16}}
     {{? it.page == 13}}
         {{#def.bookdetail}}
@@ -31,9 +31,9 @@
     </div>
     <!-- end Not book data -->
 {{??}}
-<div class="row row-cols-2 row-cols-md-5 g-0">
+<div class="row row-cols-2 row-cols-md-5 g-0" id="entries">
     {{~it.entries:entry:idx}}
-        <div class="card">
+        <div class="card" id="{{=idx}}">
             <div class="cover-image">
                 {{? entry.book.hasCover == 1}}
                     <a href="{{=entry.book.detailurl}}#cover">

--- a/templates/bootstrap5/page.html
+++ b/templates/bootstrap5/page.html
@@ -1,3 +1,3 @@
 {{#def.header}}
-{{#def.main}}
 {{#def.footer}}
+{{#def.main}}

--- a/templates/bootstrap5/page.html
+++ b/templates/bootstrap5/page.html
@@ -1,3 +1,6 @@
 {{#def.header}}
+<!-- Put footer immediately after header so that controls are easily available for pages that don't handle fixed footer well -->
 {{#def.footer}}
+<div class="container-fluid p-1" id="main">
 {{#def.main}}
+</div>

--- a/templates/bootstrap5/scripts/cops.js
+++ b/templates/bootstrap5/scripts/cops.js
@@ -6,3 +6,9 @@ function postRefresh()
     var elmnt = document.getElementById(hash);
     if (elmnt) elmnt.scrollIntoView();
 }
+
+function reverseSortEntries(){
+    currentData.entries.reverse();
+    result = templateMain(currentData);
+    $('#main').html(result);
+}


### PR DESCRIPTION
I've added a function to bootstrap5's scripts/cops.js that enables toggling the sort order, and added some doT.js logic that runs the function when clicking on the sort buttons.

It doesn't change the icon to reflect the current order, or update the url, so refresh will always revert to the default sort order.

This won't work server side, since it only works on the currentData.entries object.