### PR TITLE
Improve bootstrap5 submenu handling

### DIFF
--- a/templates/bootstrap5/header.html
+++ b/templates/bootstrap5/header.html
@@ -41,12 +41,8 @@
     </div>
   </nav>
   {{? it.containsBook != 0 || it.filters || it.isFilterPage }}
-  <script>
-    /* Add submenu class to body to give extra spacing */
-    document.body.classList.add("submenu");
-  </script>
-  <nav class="navbar bg-light py-1 ps-2" data-bs-theme="dark">
-      <ul name="2-bar" class="nav nav-pills" style="font-size: 0.8rem;">
+  <nav class="navbar bg-light py-1 ps-2" data-bs-theme="dark" id="controls-menu">
+      <ul id="2-bar" class="nav nav-pills" style="font-size: 0.8rem;">
         <li class="nav-item fw-bolder p-1 ps-2">{{=it.fullTitle}}</li>
         {{? it.containsBook != 0 }}
         <li class="nav-item p-1 border-start border-secondary-subtle">{{=it.c.i18n.sortByTitle}}:</li>

--- a/templates/bootstrap5/scripts/cops.js
+++ b/templates/bootstrap5/scripts/cops.js
@@ -6,4 +6,11 @@ function postRefresh()
     var elmnt = document.getElementById(hash);
     if (elmnt) elmnt.scrollIntoView();
     $(".tt-hint").attr("name","searchTypeahead");
+
+    /* Add submenu class to body to give extra spacing */
+   if ($("#controls-menu").length > 0) {
+    document.body.classList.add("submenu")
+   } else {
+    if (document.body.classList.contains("submenu")) document.body.classList.remove("submenu");
+   }
 }

--- a/templates/bootstrap5/scripts/cops.js
+++ b/templates/bootstrap5/scripts/cops.js
@@ -9,7 +9,7 @@ function postRefresh()
 
     /* Add submenu class to body to give extra spacing */
    if ($("#controls-menu").length > 0) {
-    document.body.classList.add("submenu")
+    document.body.classList.add("submenu");
    } else {
     if (document.body.classList.contains("submenu")) document.body.classList.remove("submenu");
    }

--- a/templates/bootstrap5/styles/bootstrap5.css
+++ b/templates/bootstrap5/styles/bootstrap5.css
@@ -33,7 +33,7 @@ body {
 }
 
 body.submenu {
-    padding: 85px 0 38px 0; /* Needed with fixed header and footer */
+    padding: 85px 0 38px 0; /* Increased padding when submenu present */
 }
 
 html {


### PR DESCRIPTION
Previously, switching to a page that didn't have a submenu left the space for the submenu at the top.  This is now fixed, and handled in scripts/cops.js