### PR TITLE
Bootstrap2 Kindle theme

### DIFF
--- a/templates/bootstrap2/bookdetail.html
+++ b/templates/bootstrap2/bookdetail.html
@@ -28,10 +28,10 @@
 
 
 <div class="col-md-4 col-sm-6 col-xs-12">
-    <h1>{{=htmlspecialchars (it.title)}}</h1>
-    <h4>{{~it.book.authors:author:i}}{{? i > 0}}, {{?}}<a href="{{=author.url}}">{{=htmlspecialchars (author.name)}}</a>{{~}}</h4>
+    <h1 class="book-title">{{=htmlspecialchars (it.title)}}</h1>
+    <h4 class="book-author">{{~it.book.authors:author:i}}{{? i > 0}}, {{?}}<a href="{{=author.url}}">{{=htmlspecialchars (author.name)}}</a>{{~}}</h4>
     {{? it.book.seriesName != ""}}
-        <h4><a href="{{=it.book.seriesurl}}">{{=htmlspecialchars (it.book.seriesName)}}</a> ({{=it.book.seriesIndex}})</h4>
+        <h4 class="book-series"><a href="{{=it.book.seriesurl}}">{{=htmlspecialchars (it.book.seriesName)}}</a> ({{=it.book.seriesIndex}})</h4>
     {{?}}
 </div>
 
@@ -62,17 +62,17 @@
 
     {{? it.book.publisherName != ""}}
     <p>
-        <h4>{{=it.c.i18n.publisherName}}: <a href="{{=it.book.publisherurl}}">{{=htmlspecialchars (it.book.publisherName)}}</a></h4>
+        <h4><span class="book-meta-label">{{=it.c.i18n.publisherName}}</span>: <a href="{{=it.book.publisherurl}}">{{=htmlspecialchars (it.book.publisherName)}}</a></h4>
     </p>
     {{?}}
     {{? it.book.pubDate != ""}}
     <p>
-        <h4>{{=it.c.i18n.pubdateTitle}}: {{=it.book.pubDate}}</h4>
+        <h4><span class="book-meta-label">{{=it.c.i18n.pubdateTitle}}</span>: {{=it.book.pubDate}}</h4>
     </p>
     {{?}}
     {{~it.book.customcolumns_preview :column:column_index}}
     <p>
-        <h4>{{=column.customColumnType.columnTitle}}: {{=column.htmlvalue}}</h4>
+        <h4><span class="book-meta-label">{{=column.customColumnType.columnTitle}}</span>: {{=column.htmlvalue}}</h4>
     </p>
     {{~}}
 
@@ -84,7 +84,7 @@
 <div class="col-md-offset-2 col-md-8 col-sm-12">    
     {{? it.book.content != ""}}
     <br />
-    <h4>{{=it.c.i18n.contentTitle}}</h4>
+    <h4 class="book-meta-label">{{=it.c.i18n.contentTitle}}</h4>
     <div>{{=it.book.content}}</div>
     {{?}}
 </div>

--- a/templates/bootstrap2/file.html
+++ b/templates/bootstrap2/file.html
@@ -199,6 +199,7 @@
 
     </style>
     <link rel="stylesheet" href="{{=it.templates}}/bootstrap2/styles/typeahead.css">
+    <link rel="stylesheet" type="text/css" href="{{=it.current_css}}?v={{=it.version}}" media="screen" />
 
 {{? it.server_side_rendering == 0}}
     <script type="text/javascript">

--- a/templates/bootstrap2/styles/style-kindle.css
+++ b/templates/bootstrap2/styles/style-kindle.css
@@ -17,6 +17,7 @@ a, a:hover {
 
 .navbar-static-top {
     padding-top: 5px;
+    padding-left:15px;
 }
 
 .navbar-brand {
@@ -41,10 +42,6 @@ a, a:hover {
 .navbar-inverse, .container-fluid {
     background-color: white;
     border:none;
-}
-
-.navbar>.container-fluid .navbar-brand {
-    margin-left: 0px; /* Fixes issue with long navbar-brand losing margin on wrap around lines. */
 }
 
 /* Navbar collapse button */

--- a/templates/bootstrap2/styles/style-kindle.css
+++ b/templates/bootstrap2/styles/style-kindle.css
@@ -1,0 +1,57 @@
+/* Override fonts, sizes and colours for Kindle eInk readers */
+
+body {
+    font-family: "Amazon Ember", Helvetica, Futura, Caecilia, Georgia, Palatino, sans-serif;
+    font-size: 25px;
+}
+
+.navbar-static-top {
+    padding-top: 5px;
+}
+
+.navbar-brand {
+    font-size: 2em;
+}
+
+.meta .title {
+    font-size: 1.8em;
+}
+
+.meta .author {
+    font-size: 1.5em;
+    font-weight: bold;
+}
+
+.btn-sm {
+    font-size: 0.6em;
+}
+
+.form-control {
+    font-size: 1.1em;
+    line-height: 1.2em;
+}
+
+input[type="checkbox"], input[type="radio"] {
+    height: 25px;
+    width: 25px;
+    margin-right: 5px;
+}
+
+.btn-success,.btn-success:hover, .btn-info,.btn-info:hover, .btn-primary, .btn-primary:hover {
+    background-color: gray;
+    border-color: gray;
+    text-decoration: none;
+}
+
+#queryInput.form-control, #searchButton {
+    height: 45px;
+}
+
+.navbar-inverse .navbar-brand, .navbar-inverse .navbar-nav>li>a {
+    color: white;
+}
+
+a {
+    color:black;
+    text-decoration: underline;
+}

--- a/templates/bootstrap2/styles/style-kindle.css
+++ b/templates/bootstrap2/styles/style-kindle.css
@@ -44,10 +44,35 @@ a, a:hover {
     border:none;
 }
 
+.panel-default>.panel-heading {
+    color: black;
+    background-color: transparent;
+    font-weight: bold;
+}
+
+.panel-body{
+    font-weight: normal;
+    color: black;
+}
+
+.panel-body label {
+    font-weight: normal;
+}
+
 /* Navbar collapse button */
 .navbar-inverse .navbar-toggle:focus, .navbar-inverse .navbar-toggle:hover {
     background-color: black;
     color:white;
+}
+
+.navbar-toggle {
+    height: 50px;
+    width: 50px;
+    padding: 12px 6px;
+}
+.navbar-toggle .icon-bar {
+    width: 80%;
+    margin: auto;
 }
 
 .navbar-inverse .navbar-nav>li>a:focus, .navbar-inverse .navbar-nav>li>a:hover, .navbar-inverse .navbar-brand:focus, .navbar-inverse .navbar-brand:hover {

--- a/templates/bootstrap2/styles/style-kindle.css
+++ b/templates/bootstrap2/styles/style-kindle.css
@@ -123,6 +123,13 @@ input#email, input#max_item_per_page, select#style, select#template { /* prevent
     height: 45px;
 }
 
+#searchButton {
+    width: 50px;
+    padding-left:16px;
+    padding-top: 10px;
+    font-size: 18px;
+}
+
 .book-meta-label, .book-title, .book-author {
     font-weight: bold;
 }

--- a/templates/bootstrap2/styles/style-kindle.css
+++ b/templates/bootstrap2/styles/style-kindle.css
@@ -21,6 +21,11 @@ a, a:hover {
 
 .navbar-brand {
     font-size: 2em;
+    line-height: 1.2em;
+    margin-bottom: 10px;
+    float:none;
+    font-weight: bold;
+    padding: 0px;
 }
 
 .navbar > div {
@@ -29,8 +34,17 @@ a, a:hover {
     color: black;
 }
 
-.navbar-inverse .navbar-brand, .navbar-inverse .navbar-nav>li>a {
+.navbar-inverse .navbar-brand, .navbar-inverse .navbar-nav>li>a, span.glyphicon.glyphicon-tags {
     color: black;
+}
+
+.navbar-inverse, .container-fluid {
+    background-color: white;
+    border:none;
+}
+
+.navbar>.container-fluid .navbar-brand {
+    margin-left: 0px; /* Fixes issue with long navbar-brand losing margin on wrap around lines. */
 }
 
 /* Navbar collapse button */
@@ -87,6 +101,6 @@ input[type="checkbox"], input[type="radio"] {
     font-weight: bold;
 }
 
-.badge {
+.badge, .label-default {
     background-color: black;
 }

--- a/templates/bootstrap2/styles/style-kindle.css
+++ b/templates/bootstrap2/styles/style-kindle.css
@@ -87,6 +87,10 @@ input[type="checkbox"], input[type="radio"] {
     margin-right: 5px;
 }
 
+input#email, input#max_item_per_page, select#style, select#template { /* prevents overlap */
+    width: 100%;
+}
+
 .btn-success,.btn-success:hover, .btn-info,.btn-info:hover, .btn-primary, .btn-primary:hover, .navbar-toggle {
     background-color: black;
     border-color: black;

--- a/templates/bootstrap2/styles/style-kindle.css
+++ b/templates/bootstrap2/styles/style-kindle.css
@@ -3,6 +3,16 @@
 body {
     font-family: "Amazon Ember", Helvetica, Futura, Caecilia, Georgia, Palatino, sans-serif;
     font-size: 25px;
+    background-color: white;
+}
+
+.h1, .h2, .h3, .h4, .h5, .h6, h1, h2, h3, h4, h5, h6 {
+    color:black;
+}
+
+a, a:hover {
+    color:black;
+    text-decoration: underline;
 }
 
 .navbar-static-top {
@@ -11,6 +21,32 @@ body {
 
 .navbar-brand {
     font-size: 2em;
+}
+
+.navbar > div {
+    background-color: white;
+    border-bottom: solid 1px black;
+    color: black;
+}
+
+.navbar-inverse .navbar-brand, .navbar-inverse .navbar-nav>li>a {
+    color: black;
+}
+
+/* Navbar collapse button */
+.navbar-inverse .navbar-toggle:focus, .navbar-inverse .navbar-toggle:hover {
+    background-color: black;
+    color:white;
+}
+
+.navbar-inverse .navbar-nav>li>a:focus, .navbar-inverse .navbar-nav>li>a:hover, .navbar-inverse .navbar-brand:focus, .navbar-inverse .navbar-brand:hover {
+    color:black;
+    background-color: transparent;
+    text-decoration: underline;
+}
+
+.navbar-inverse .navbar-form {
+    border: none;
 }
 
 .meta .title {
@@ -37,9 +73,9 @@ input[type="checkbox"], input[type="radio"] {
     margin-right: 5px;
 }
 
-.btn-success,.btn-success:hover, .btn-info,.btn-info:hover, .btn-primary, .btn-primary:hover {
-    background-color: gray;
-    border-color: gray;
+.btn-success,.btn-success:hover, .btn-info,.btn-info:hover, .btn-primary, .btn-primary:hover, .navbar-toggle {
+    background-color: black;
+    border-color: black;
     text-decoration: none;
 }
 
@@ -47,15 +83,10 @@ input[type="checkbox"], input[type="radio"] {
     height: 45px;
 }
 
-.navbar-inverse .navbar-brand, .navbar-inverse .navbar-nav>li>a {
-    color: white;
-}
-
-a {
-    color:black;
-    text-decoration: underline;
-}
-
 .book-meta-label, .book-title, .book-author {
     font-weight: bold;
+}
+
+.badge {
+    background-color: black;
 }

--- a/templates/bootstrap2/styles/style-kindle.css
+++ b/templates/bootstrap2/styles/style-kindle.css
@@ -55,3 +55,7 @@ a {
     color:black;
     text-decoration: underline;
 }
+
+.book-meta-label, .book-title, .book-author {
+    font-weight: bold;
+}


### PR DESCRIPTION
I started making a template specifically for Kindle, but while doing it I thought I would have a go making a more Kindle friendly theme for the bootstrap2 template. I think it works pretty well on Kindle, and possibly any other eInk device where black and white with minimal gray scale looks better.

It doesn't work with the original bootstrap template, nor bootstrap5.

Any chance you could take a look in any eInk devices you have, or even just a sanity check in a regular browser?