### PR TITLE
Use browscap-php to detect JavaScript supported version

### DIFF
--- a/browsercheck.php
+++ b/browsercheck.php
@@ -1,0 +1,24 @@
+<h2>Detected browser</h2>
+<?php
+require 'vendor/autoload.php';
+print($_SERVER['HTTP_USER_AGENT'] . "\n\n");
+
+use MatthiasMullie\Scrapbook\Psr16\SimpleCache;
+use League\Flysystem\Local\LocalFilesystemAdapter;
+use League\Flysystem\Filesystem;
+use MatthiasMullie\Scrapbook\Adapters\Flysystem;
+use Monolog\Logger;
+
+$dir        = __DIR__ . "/vendor/browscap/browscap-php/resources";
+$adapter    = new LocalFilesystemAdapter($dir);
+$filesystem = new Filesystem($adapter);
+$cache      = new SimpleCache(
+    new Flysystem($filesystem)
+);
+
+$logger = new Logger('name');
+$parser = new Browscap($cache, $logger);
+
+$result = $parser->getBrowser($useragent);
+print($result);
+?>

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,8 @@
         "npm-asset/corejs-typeahead": "~1.3",
         "npm-asset/twig": "~1.16",
         "phpmailer/phpmailer": "~6.8",
-        "twig/twig": "~3.7"
+        "twig/twig": "~3.7",
+        "browscap/browscap-php": "^7.2.0"
     },
     "require-dev": {
         "kiwilan/php-opds": "~1.0.30",


### PR DESCRIPTION
See #62 for background.

Currently COPS is searching the user agent string to determine which browsers to send to server-side rendering.

A better approach might be to check browser capabilities, which can be done in a couple of ways:
**JavaScript client side check**
JavaScript run inside a <script nomodule> tag will be ignored by browsers that support ES6 and up.

**PHP server side check**
The [browscap-php](https://github.com/browscap/browscap-php) package should allow checking the version of JavaScript that is supported by the browser through . Unfortunately I have yet to figure out how to get browscap-php working. I have managed to get it installed via composer, and used its commands to fetch and convert the browsercap.ini file, but stuck at actually writing code that gets the info. The documentation assumes a lot of knowledge I don't have.

This PR is specifically about getting browscap-php to work.