### PR TITLE
Make kobo browser use server side by default

### DIFF
--- a/checkconfig.php
+++ b/checkconfig.php
@@ -199,6 +199,8 @@ if ($request->render()) {
 }
 ?>
             </h4>
+            <h2>User agent detected</h2>
+            <h4><?php echo $_SERVER["HTTP_USER_AGENT"] ?></h4>
         </article>
 <?php
 $i = 0;

--- a/config_default.php
+++ b/config_default.php
@@ -325,7 +325,7 @@ $config['cops_thumbnail_cache_directory'] = '';
  * For now : Kindle, Sony PRS-T1, Sony PRS-T2, All Cybook devices (maybe a little extreme).
  * This item is used as regular expression so "." will force server side rendering for all devices
  */
-$config['cops_server_side_render'] = 'Kindle\/1\.0|Kindle\/2\.0|Kindle\/3\.0|EBRD1101|EBRD1201|cybook';
+$config['cops_server_side_render'] = 'Kindle\/1\.0|Kindle\/2\.0|Kindle\/3\.0|EBRD1101|EBRD1201|cybook|Kobo';
 
 /*
  * Specify the ignored categories for the home screen and with search

--- a/config_default.php
+++ b/config_default.php
@@ -325,7 +325,7 @@ $config['cops_thumbnail_cache_directory'] = '';
  * For now : Kindle, Sony PRS-T1, Sony PRS-T2, All Cybook devices (maybe a little extreme).
  * This item is used as regular expression so "." will force server side rendering for all devices
  */
-$config['cops_server_side_render'] = 'Kindle\/1\.0|Kindle\/2\.0|Kindle\/3\.0|EBRD1101|EBRD1201|cybook|Kobo';
+$config['cops_server_side_render'] = 'Kindle\/1\.\d|Kindle\/2\.\d|Kindle\/3\.\d|EBRD1101|EBRD1201|cybook|Kobo';
 
 /*
  * Specify the ignored categories for the home screen and with search


### PR DESCRIPTION
Some updates to the string used to determine whether to use server side rendering or not:

* Include Kobo browsers
* Include point releases of Kindle browser as [these have been reported in the wild](https://whatmyuseragent.com/browser/ki/kindle-browser/3).
* Display the user agent in config.php since this can be useful for troubleshooting