### PR TITLE
Render custom (long-text) columns with whitespace: pre-wrap

### DIFF
--- a/lib/Calibre/CustomColumnTypeBool.php
+++ b/lib/Calibre/CustomColumnTypeBool.php
@@ -29,10 +29,11 @@ class CustomColumnTypeBool extends CustomColumnType
      * Summary of __construct
      * @param int $pcustomId
      * @param ?int $database
+     * @param array $displaySettings
      */
-    protected function __construct($pcustomId, $database)
+    protected function __construct($pcustomId, $database, $displaySettings)
     {
-        parent::__construct($pcustomId, static::TYPE_BOOL, $database);
+        parent::__construct($pcustomId, static::TYPE_BOOL, $database, $displaySettings);
     }
 
     /**

--- a/lib/Calibre/CustomColumnTypeComment.php
+++ b/lib/Calibre/CustomColumnTypeComment.php
@@ -17,10 +17,11 @@ class CustomColumnTypeComment extends CustomColumnType
      * Summary of __construct
      * @param int $pcustomId
      * @param ?int $database
+     * @param array $displaySettings
      */
-    protected function __construct($pcustomId, $database)
+    protected function __construct($pcustomId, $database, $displaySettings)
     {
-        parent::__construct($pcustomId, static::TYPE_COMMENT, $database);
+        parent::__construct($pcustomId, static::TYPE_COMMENT, $database, $displaySettings);
     }
 
     /**

--- a/lib/Calibre/CustomColumnTypeDate.php
+++ b/lib/Calibre/CustomColumnTypeDate.php
@@ -27,10 +27,11 @@ class CustomColumnTypeDate extends CustomColumnType
      * Summary of __construct
      * @param int $pcustomId
      * @param ?int $database
+     * @param array $displaySettings
      */
-    protected function __construct($pcustomId, $database)
+    protected function __construct($pcustomId, $database, $displaySettings)
     {
-        parent::__construct($pcustomId, static::TYPE_DATE, $database);
+        parent::__construct($pcustomId, static::TYPE_DATE, $database, $displaySettings);
     }
 
     /**

--- a/lib/Calibre/CustomColumnTypeEnumeration.php
+++ b/lib/Calibre/CustomColumnTypeEnumeration.php
@@ -17,10 +17,11 @@ class CustomColumnTypeEnumeration extends CustomColumnType
      * Summary of __construct
      * @param int $pcustomId
      * @param ?int $database
+     * @param array $displaySettings
      */
-    protected function __construct($pcustomId, $database)
+    protected function __construct($pcustomId, $database, $displaySettings)
     {
-        parent::__construct($pcustomId, static::TYPE_ENUM, $database);
+        parent::__construct($pcustomId, static::TYPE_ENUM, $database, $displaySettings);
     }
 
     /**

--- a/lib/Calibre/CustomColumnTypeFloat.php
+++ b/lib/Calibre/CustomColumnTypeFloat.php
@@ -20,10 +20,11 @@ class CustomColumnTypeFloat extends CustomColumnType
      * Summary of __construct
      * @param int $pcustomId
      * @param ?int $database
+     * @param array $displaySettings
      */
-    protected function __construct($pcustomId, $database)
+    protected function __construct($pcustomId, $database, $displaySettings)
     {
-        parent::__construct($pcustomId, static::TYPE_FLOAT, $database);
+        parent::__construct($pcustomId, static::TYPE_FLOAT, $database, $displaySettings);
     }
 
     /**

--- a/lib/Calibre/CustomColumnTypeInteger.php
+++ b/lib/Calibre/CustomColumnTypeInteger.php
@@ -23,16 +23,17 @@ class CustomColumnTypeInteger extends CustomColumnType
      * @param int $pcustomId
      * @param string $datatype
      * @param ?int $database
+     * @param array $displaySettings
      * @throws \UnexpectedValueException
      */
-    protected function __construct($pcustomId, $datatype = self::TYPE_INT, $database = null)
+    protected function __construct($pcustomId, $datatype, $database, $displaySettings)
     {
         switch ($datatype) {
             case static::TYPE_INT:
-                parent::__construct($pcustomId, static::TYPE_INT, $database);
+                parent::__construct($pcustomId, static::TYPE_INT, $database, $displaySettings);
                 break;
             case static::TYPE_FLOAT:
-                parent::__construct($pcustomId, static::TYPE_FLOAT, $database);
+                parent::__construct($pcustomId, static::TYPE_FLOAT, $database, $displaySettings);
                 break;
             default:
                 throw new UnexpectedValueException();

--- a/lib/Calibre/CustomColumnTypeRating.php
+++ b/lib/Calibre/CustomColumnTypeRating.php
@@ -25,10 +25,11 @@ class CustomColumnTypeRating extends CustomColumnType
      * Summary of __construct
      * @param int $pcustomId
      * @param ?int $database
+     * @param array $displaySettings
      */
-    protected function __construct($pcustomId, $database)
+    protected function __construct($pcustomId, $database, $displaySettings)
     {
-        parent::__construct($pcustomId, static::TYPE_RATING, $database);
+        parent::__construct($pcustomId, static::TYPE_RATING, $database, $displaySettings);
     }
 
     /**

--- a/lib/Calibre/CustomColumnTypeSeries.php
+++ b/lib/Calibre/CustomColumnTypeSeries.php
@@ -17,10 +17,11 @@ class CustomColumnTypeSeries extends CustomColumnType
      * Summary of __construct
      * @param int $pcustomId
      * @param ?int $database
+     * @param array $displaySettings
      */
-    protected function __construct($pcustomId, $database = null)
+    protected function __construct($pcustomId, $database, $displaySettings)
     {
-        parent::__construct($pcustomId, static::TYPE_SERIES, $database);
+        parent::__construct($pcustomId, static::TYPE_SERIES, $database, $displaySettings);
     }
 
     /**

--- a/lib/Calibre/CustomColumnTypeText.php
+++ b/lib/Calibre/CustomColumnTypeText.php
@@ -19,23 +19,24 @@ class CustomColumnTypeText extends CustomColumnType
      * @param int $pcustomId
      * @param string $datatype
      * @param ?int $database
-     * @throws \UnexpectedValueException
+     * @param array $displaySettings
      * @return void
+     *@throws \UnexpectedValueException
      */
-    protected function __construct($pcustomId, $datatype = self::TYPE_TEXT, $database = null)
+    protected function __construct($pcustomId, $datatype, $database, $displaySettings)
     {
         switch ($datatype) {
             case static::TYPE_TEXT:
-                parent::__construct($pcustomId, static::TYPE_TEXT, $database);
+                parent::__construct($pcustomId, static::TYPE_TEXT, $database, $displaySettings);
                 return;
             case static::TYPE_CSV:
-                parent::__construct($pcustomId, static::TYPE_CSV, $database);
+                parent::__construct($pcustomId, static::TYPE_CSV, $database, $displaySettings);
                 return;
             case static::TYPE_ENUM:
-                parent::__construct($pcustomId, static::TYPE_ENUM, $database);
+                parent::__construct($pcustomId, static::TYPE_ENUM, $database, $displaySettings);
                 return;
             case static::TYPE_SERIES:
-                parent::__construct($pcustomId, static::TYPE_SERIES, $database);
+                parent::__construct($pcustomId, static::TYPE_SERIES, $database, $displaySettings);
                 return;
             default:
                 throw new UnexpectedValueException();

--- a/templates/default/bookdetail.html
+++ b/templates/default/bookdetail.html
@@ -56,7 +56,10 @@
     {{?}}
     {{~it.book.customcolumns_preview :column:column_index}}
     <p class="popupless">
-    <h3>{{=column.customColumnType.columnTitle}}: </h3>{{=column.htmlvalue}}
+    <h3>{{=column.customColumnType.columnTitle}}: </h3>
+    <div class="customcolumncontent"
+         data-customcolumn-datatype="{{=column.customColumnType.datatype}}"
+         data-customcolumn-interpretas="{{=column.customColumnType.displaySettings.interpret_as ?? ''}}">{{=column.htmlvalue}}</div>
     </p>
     {{~}}
     {{? it.book.content != ""}}

--- a/templates/default/styles/style-base.css
+++ b/templates/default/styles/style-base.css
@@ -271,6 +271,17 @@ max-width:800px;
     font-style: italic;
 }
 
+.customcolumncontent {
+    display: inline;
+}
+
+.customcolumncontent[data-customcolumn-datatype='comments'][data-customcolumn-interpretas='long-text'],
+.customcolumncontent[data-customcolumn-datatype='comments'][data-customcolumn-interpretas='html'],
+.customcolumncontent[data-customcolumn-datatype='comments'][data-customcolumn-interpretas='markdown'] {
+    display: block;
+    white-space: pre-wrap;
+}
+
 /*-------------books popup article-------------*/
 .bookpopup h2{
     margin: 15px 15px;


### PR DESCRIPTION
Currently  if we show the content of a custom column of type `comments` (in the book preview) we loose all line-breaks and leading whitespaces.

![image](https://github.com/mikespub-org/seblucas-cops/assets/175731/67c7c790-3d2c-477a-92b1-03dbbd4bd2bf)

This commit PR parses the `display` column from the database and adds `white-space: pre-wrap`, to properly render the content (if `interpret_as` is either `html`, `long-text` or `markdown`).  
For the fourth possible interpret-as value `short-text`, we keep the current `display: inline` behavior.

![image](https://github.com/mikespub-org/seblucas-cops/assets/175731/2f856290-a6a4-4731-aebc-c6a225579576)

In the future it could be nice to really render the content if  `interpret_as` is `html` or `markdown`. (Markdown would be pretty easy, but html would need a proper html sanitizer to prevent XSS)...