### PR TITLE
clarify arch support from linuxserver.io (remove armhf)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ On Centos you may have to add :
 3.  Edit config_local.php to match your config.
 4.  If needed add other configuration item from config_default.php
 
-If you like Docker, you can also try this multiarch docker container from [linuxserver.io](https://hub.docker.com/r/linuxserver/cops/)  It has builds for x64, armhf and arm64. 
+If you like Docker, you can also try this multiarch docker container from [linuxserver.io](https://hub.docker.com/r/linuxserver/cops/)  It has builds for x64 and arm64. 
 
 # Install from sources
 


### PR DESCRIPTION
The readme indicates that we support armhf, but as of July 1, 2023, we no longer build for armhf. Our suggestion is that users check if their device supports 64bit and FORMAT and reinstall. Unfortunately, raspi's will upgrade the kernel from 32bit to 64bit but leave 32bit userland leaving docker to think it is still armhf. 

I THINK there could be a change to the prereq section which indicates 7.x is the php requirement, but I wasn't sure how you were trying to convey the info since php 8.x support is mentioned elsewhere in the readme.