### PR TITLE
Default settings for epubjs-reader

### DIFF
--- a/config_default.php
+++ b/config_default.php
@@ -605,4 +605,4 @@ $config['cops_epubjs_reader_settings'] = '{
     fullscreen: document.fullscreenEnabled // default behaviour
 }';
  */
-$config['cops_epubjs_reader_settings'] = '{ openbook: false }';
+$config['cops_epubjs_reader_settings'] = '{ arrows: "content", flow: "paginated", openbook: false }';


### PR DESCRIPTION
Proposed default settings for epubjs-reader in COPS till swiping on mobile devices is fixed.