### PR TITLE
Fix thumbnails and add series list to author page in bootstrap5 template

### DIFF
--- a/templates/bootstrap5/file.html
+++ b/templates/bootstrap5/file.html
@@ -30,8 +30,8 @@
     <link rel="icon" type="image/vnd.microsoft.icon" href="{{=it.favico}}" />
 
     <!-- Latest compiled and minified CSS -->
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-4bw+/aepP/YC94hEpVNVgiZdgIC5+VKNBQNGCHeKRQN+PtmoHDEXuppvnDJzQIu9" crossorigin="anonymous">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-4bw+/aepP/YC94hEpVNVgiZdgIC5+VKNBQNGCHeKRQN+PtmoHDEXuppvnDJzQIu9" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
     <!-- Latest compiled and minified JavaScript -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-HwwvtgBNo3bZJJLYd8oVXjrBZt8cqVSpeBNS5n7C8IVInixGAoxmnlMuBnhbgrkm" crossorigin="anonymous"></script>
     <link rel="stylesheet" href="{{=it.templates}}/bootstrap5/styles/bootstrap5.css">

--- a/templates/bootstrap5/file.html
+++ b/templates/bootstrap5/file.html
@@ -33,7 +33,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-4bw+/aepP/YC94hEpVNVgiZdgIC5+VKNBQNGCHeKRQN+PtmoHDEXuppvnDJzQIu9" crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
     <!-- Latest compiled and minified JavaScript -->
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js" integrity="sha384-HwwvtgBNo3bZJJLYd8oVXjrBZt8cqVSpeBNS5n7C8IVInixGAoxmnlMuBnhbgrkm" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-HwwvtgBNo3bZJJLYd8oVXjrBZt8cqVSpeBNS5n7C8IVInixGAoxmnlMuBnhbgrkm" crossorigin="anonymous"></script>
     <link rel="stylesheet" href="{{=it.templates}}/bootstrap5/styles/bootstrap5.css">
     <link rel="stylesheet" href="{{=it.templates}}/bootstrap5/styles/typeahead.css">
 

--- a/templates/bootstrap5/main.html
+++ b/templates/bootstrap5/main.html
@@ -37,7 +37,7 @@
             <div class="cover-image">
                 {{? entry.book.hasCover == 1}}
                     <a href="{{=entry.book.detailurl}}#cover">
-                        <img class ="card-image-top" src="{{=str_format (it.c.url.thumbnailUrl, entry.book.id, it.databaseId)}}" alt="{{=it.c.i18n.coverAlt}}" />
+                        <img class ="card-image-top" src="{{=entry.thumbnailurl}}" alt="{{=it.c.i18n.coverAlt}}" />
                     </a>
                 {{?}}
             </div>
@@ -79,6 +79,34 @@
         <li class="page-item{{? it.nextLink == ""}} disabled{{?}}"><a id="nextLink" class="page-link" href="{{=it.nextLink}}">{{=it.c.i18n.nextAlt}}<i class="bi-chevron-right"></i></a></li>
     </ul>
 </nav>
+{{?}}
+{{? it.extra }}
+    {{? it.extra.series }}
+    <div class="card mt-1">
+        <div class="card-header">{{=it.c.i18n.seriesTitle}}</div>
+        <div class="card-body">
+            <ul class="list-group list-group-flush">
+            {{~it.extra.series:series:idx}}
+                <li class="list-group-item"><a href="{{=series.navlink}}" class="card-link">{{=series.title}}</a> ({{=series.number}})</li>
+            {{~}}
+            </ul>
+        </div>
+    </div>
+    {{?}}
+    {{? it.extra.title }}
+    <div class="card mt-1">
+        <div class="card-header">{{=it.extra.title}}</div>
+        <div class="card-body">
+        {{? it.extra.link }}
+        <p class="card-text">{{=it.c.i18n.linkTitle}}: <a rel="external" target="_blank" href="{{=it.extra.link}}" class="card-link">{{=it.extra.link}}</a></p>
+        {{?}}
+        {{? it.extra.content }}
+            {{=it.extra.content}}
+        {{?}}
+        </div>
+    </div>
+    {{?}}
+
 {{?}}
 </div>
 <div id="error"></div>


### PR DESCRIPTION
* Bootstrap5 template was no longer displaying cover thumbnails - fixed
* Added series list to authors page in bootstrap5 template, as well as extra.title section below - I'm not really sure what this is for, but this brings bootstrap5 inline with bootstrap2 and twigged.
