### PR TITLE
Fix Kindle cookie functions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "npm-asset/bootstrap": "^3.4",
         "npm-asset/dot": "^1.1",
         "npm-asset/jquery": "^3.7",
-        "npm-asset/js-cookie": "^3.0",
+        "npm-asset/js-cookie": "1.5.1",
         "npm-asset/lru-fast": "^0.2",
         "npm-asset/magnific-popup": "^1.2",
         "npm-asset/normalize.css": "^8.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "549436bb329719a14a5fb3ff2e4ccce3",
+    "content-hash": "a893f7bc7be1e75edecbdf6d1d195331",
     "packages": [
         {
             "name": "maennchen/zipstream-php",
@@ -132,16 +132,16 @@
         },
         {
             "name": "mikespub/php-epub-meta",
-            "version": "3.3.5",
+            "version": "3.3.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mikespub-org/php-epub-meta.git",
-                "reference": "d522c610373809eb802d186fef0b3a07b7357ded"
+                "reference": "a721ffff66c8ff310e7b38e11a261bf2411cfefb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mikespub-org/php-epub-meta/zipball/d522c610373809eb802d186fef0b3a07b7357ded",
-                "reference": "d522c610373809eb802d186fef0b3a07b7357ded",
+                "url": "https://api.github.com/repos/mikespub-org/php-epub-meta/zipball/a721ffff66c8ff310e7b38e11a261bf2411cfefb",
+                "reference": "a721ffff66c8ff310e7b38e11a261bf2411cfefb",
                 "shasum": ""
             },
             "require": {
@@ -198,9 +198,9 @@
             ],
             "support": {
                 "issues": "https://github.com/mikespub-org/php-epub-meta/issues",
-                "source": "https://github.com/mikespub-org/php-epub-meta/tree/3.3.5"
+                "source": "https://github.com/mikespub-org/php-epub-meta/tree/3.3.6"
             },
-            "time": "2025-02-20T20:47:56+00:00"
+            "time": "2025-04-24T13:51:06+00:00"
         },
         {
             "name": "npm-asset/babel--runtime",
@@ -322,10 +322,10 @@
         },
         {
             "name": "npm-asset/js-cookie",
-            "version": "3.0.5",
+            "version": "1.5.1",
             "dist": {
                 "type": "tar",
-                "url": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz"
+                "url": "https://registry.npmjs.org/js-cookie/-/js-cookie-1.5.1.tgz"
             },
             "type": "npm-asset",
             "license": [
@@ -442,16 +442,16 @@
         },
         {
             "name": "phpmailer/phpmailer",
-            "version": "v6.9.3",
+            "version": "v6.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPMailer/PHPMailer.git",
-                "reference": "2f5c94fe7493efc213f643c23b1b1c249d40f47e"
+                "reference": "bf74d75a1fde6beaa34a0ddae2ec5fce0f72a144"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPMailer/PHPMailer/zipball/2f5c94fe7493efc213f643c23b1b1c249d40f47e",
-                "reference": "2f5c94fe7493efc213f643c23b1b1c249d40f47e",
+                "url": "https://api.github.com/repos/PHPMailer/PHPMailer/zipball/bf74d75a1fde6beaa34a0ddae2ec5fce0f72a144",
+                "reference": "bf74d75a1fde6beaa34a0ddae2ec5fce0f72a144",
                 "shasum": ""
             },
             "require": {
@@ -511,7 +511,7 @@
             "description": "PHPMailer is a full-featured email creation and transfer class for PHP",
             "support": {
                 "issues": "https://github.com/PHPMailer/PHPMailer/issues",
-                "source": "https://github.com/PHPMailer/PHPMailer/tree/v6.9.3"
+                "source": "https://github.com/PHPMailer/PHPMailer/tree/v6.10.0"
             },
             "funding": [
                 {
@@ -519,7 +519,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-11-24T18:04:13+00:00"
+            "time": "2025-04-24T15:19:31+00:00"
         },
         {
             "name": "symfony/config",
@@ -1376,16 +1376,16 @@
     "packages-dev": [
         {
             "name": "illuminate/collections",
-            "version": "v12.9.2",
+            "version": "v12.10.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/collections.git",
-                "reference": "811d8676fd7030a7f69b8f298a278c7fd5c67af3"
+                "reference": "7f8a89e1e484fea952cdd8400bab2e277fa4f903"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/collections/zipball/811d8676fd7030a7f69b8f298a278c7fd5c67af3",
-                "reference": "811d8676fd7030a7f69b8f298a278c7fd5c67af3",
+                "url": "https://api.github.com/repos/illuminate/collections/zipball/7f8a89e1e484fea952cdd8400bab2e277fa4f903",
+                "reference": "7f8a89e1e484fea952cdd8400bab2e277fa4f903",
                 "shasum": ""
             },
             "require": {
@@ -1429,20 +1429,20 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2025-04-14T15:21:48+00:00"
+            "time": "2025-04-21T14:14:46+00:00"
         },
         {
             "name": "illuminate/conditionable",
-            "version": "v12.9.2",
+            "version": "v12.10.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/conditionable.git",
-                "reference": "251ef166c6ee46cc8a141403253f83fe7ee50507"
+                "reference": "455a28c08f849db93078c9a60d765b88011affd2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/conditionable/zipball/251ef166c6ee46cc8a141403253f83fe7ee50507",
-                "reference": "251ef166c6ee46cc8a141403253f83fe7ee50507",
+                "url": "https://api.github.com/repos/illuminate/conditionable/zipball/455a28c08f849db93078c9a60d765b88011affd2",
+                "reference": "455a28c08f849db93078c9a60d765b88011affd2",
                 "shasum": ""
             },
             "require": {
@@ -1475,11 +1475,11 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2025-03-19T20:10:05+00:00"
+            "time": "2025-04-23T12:59:28+00:00"
         },
         {
             "name": "illuminate/contracts",
-            "version": "v12.9.2",
+            "version": "v12.10.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/contracts.git",
@@ -1527,7 +1527,7 @@
         },
         {
             "name": "illuminate/macroable",
-            "version": "v12.9.2",
+            "version": "v12.10.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/macroable.git",
@@ -1706,16 +1706,16 @@
         },
         {
             "name": "mikespub/epub-loader",
-            "version": "3.6.1",
+            "version": "3.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mikespub-org/epub-loader.git",
-                "reference": "f5b6a9240b9ecd394dd75032d730ff7226208a2f"
+                "reference": "18491ea12e27c14c2297b98847c13ee42e2d8019"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mikespub-org/epub-loader/zipball/f5b6a9240b9ecd394dd75032d730ff7226208a2f",
-                "reference": "f5b6a9240b9ecd394dd75032d730ff7226208a2f",
+                "url": "https://api.github.com/repos/mikespub-org/epub-loader/zipball/18491ea12e27c14c2297b98847c13ee42e2d8019",
+                "reference": "18491ea12e27c14c2297b98847c13ee42e2d8019",
                 "shasum": ""
             },
             "require": {
@@ -1771,9 +1771,9 @@
             "description": "epub-loader is a utility resource for ebooks",
             "support": {
                 "issues": "https://github.com/mikespub-org/epub-loader/issues",
-                "source": "https://github.com/mikespub-org/epub-loader/tree/3.6.1"
+                "source": "https://github.com/mikespub-org/epub-loader/tree/3.6.2"
             },
-            "time": "2025-02-20T21:00:22+00:00"
+            "time": "2025-04-24T14:34:47+00:00"
         },
         {
             "name": "mikespub/survos-wikidata",

--- a/templates/bootstrap/file.html
+++ b/templates/bootstrap/file.html
@@ -15,7 +15,7 @@
     <title>{{=it.title}}</title>
 
     <script type="text/javascript" src="{{=it.assets}}/jquery/dist/jquery.min.js?v={{=it.version}}"></script>
-    <script type="text/javascript" src="{{=it.assets}}/js-cookie/dist/js.cookie.js?v={{=it.version}}"></script>
+    <script type="text/javascript" src="{{=it.assets}}/js-cookie/src/js.cookie.js?v={{=it.version}}"></script>
     <script type="text/javascript" src="{{=it.resources}}/simonpioli/sortelements/jquery.sortElements.js?v={{=it.version}}"></script>
 {{? it.server_side_rendering == 0}}
     <script type="text/javascript" src="{{=it.assets}}/magnific-popup/dist/jquery.magnific-popup.min.js?v={{=it.version}}"></script>

--- a/templates/bootstrap2/file.html
+++ b/templates/bootstrap2/file.html
@@ -15,7 +15,7 @@
     <title>{{=it.title}}</title>
 
     <script type="text/javascript" src="{{=it.assets}}/jquery/dist/jquery.min.js?v={{=it.version}}"></script>
-    <script type="text/javascript" src="{{=it.assets}}/js-cookie/dist/js.cookie.js?v={{=it.version}}"></script>
+    <script type="text/javascript" src="{{=it.assets}}/js-cookie/src/js.cookie.js?v={{=it.version}}"></script>
     <script type="text/javascript" src="{{=it.resources}}/simonpioli/sortelements/jquery.sortElements.js?v={{=it.version}}"></script>
 {{? it.server_side_rendering == 0}}
     <script type="text/javascript" src="{{=it.assets}}/magnific-popup/dist/jquery.magnific-popup.min.js?v={{=it.version}}"></script>

--- a/templates/bootstrap5/file.html
+++ b/templates/bootstrap5/file.html
@@ -15,7 +15,7 @@
     <title>{{=it.title}}</title>
 
     <script type="text/javascript" src="{{=it.assets}}/jquery/dist/jquery.min.js?v={{=it.version}}"></script>
-    <script type="text/javascript" src="{{=it.assets}}/js-cookie/dist/js.cookie.js?v={{=it.version}}"></script>
+    <script type="text/javascript" src="{{=it.assets}}/js-cookie/src/js.cookie.js?v={{=it.version}}"></script>
     <script type="text/javascript" src="{{=it.resources}}/simonpioli/sortelements/jquery.sortElements.js?v={{=it.version}}"></script>
 {{? it.server_side_rendering == 0}}
     <script type="text/javascript" src="{{=it.assets}}/magnific-popup/dist/jquery.magnific-popup.min.js?v={{=it.version}}"></script>

--- a/templates/default/file.html
+++ b/templates/default/file.html
@@ -15,7 +15,7 @@
     <title>{{=it.title}}</title>
 
     <script type="text/javascript" src="{{=it.assets}}/jquery/dist/jquery.min.js?v={{=it.version}}"></script>
-    <script type="text/javascript" src="{{=it.assets}}/js-cookie/dist/js.cookie.js?v={{=it.version}}"></script>
+    <script type="text/javascript" src="{{=it.assets}}/js-cookie/src/js.cookie.js?v={{=it.version}}"></script>
     <script type="text/javascript" src="{{=it.resources}}/simonpioli/sortelements/jquery.sortElements.js?v={{=it.version}}"></script>
 {{? it.server_side_rendering == 0}}
     <script type="text/javascript" src="{{=it.assets}}/magnific-popup/dist/jquery.magnific-popup.min.js?v={{=it.version}}"></script>

--- a/templates/twigged/index.html
+++ b/templates/twigged/index.html
@@ -15,7 +15,7 @@
     <title>{{it.title}}</title>
 
     <script type="text/javascript" src="{{asset('jquery/dist/jquery.min.js')}}"></script>
-    <script type="text/javascript" src="{{asset('js-cookie/dist/js.cookie.js')}}"></script>
+    <script type="text/javascript" src="{{asset('js-cookie/src/js.cookie.js')}}"></script>
     <script type="text/javascript" src="{{it.resources}}/simonpioli/sortelements/jquery.sortElements.js?v={{it.version}}"></script>
 {% if it.server_side_rendering == 0 %}
     <script type="text/javascript" src="{{asset('magnific-popup/dist/jquery.magnific-popup.min.js')}}"></script>


### PR DESCRIPTION
js-cookie 1.5.1 works with Kindle browser.  Downgrading it to that version allows the cookie functions in customize page to work again.  

- I've tested the main template and theme switchers.
- The number of books displayed (just noticed this doesn't seem to work on the recent additions page)
- Ignored categories

I haven't tested email for sending mail, enable tag filtering or virtual libraries yet, but as long as they rely on simple cookie reading there is a good chance they will.