### PR TITLE
Replace js-cookie

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,6 @@
         "npm-asset/bootstrap": "^3.4",
         "npm-asset/dot": "^1.1",
         "npm-asset/jquery": "^3.7",
-        "npm-asset/js-cookie": "^3.0",
         "npm-asset/lru-fast": "^0.2",
         "npm-asset/magnific-popup": "^1.2",
         "npm-asset/normalize.css": "^8.0",

--- a/templates/bootstrap/file.html
+++ b/templates/bootstrap/file.html
@@ -15,7 +15,6 @@
     <title>{{=it.title}}</title>
 
     <script type="text/javascript" src="{{=it.assets}}/jquery/dist/jquery.min.js?v={{=it.version}}"></script>
-    <script type="text/javascript" src="{{=it.assets}}/js-cookie/dist/js.cookie.js?v={{=it.version}}"></script>
     <script type="text/javascript" src="{{=it.resources}}/simonpioli/sortelements/jquery.sortElements.js?v={{=it.version}}"></script>
 {{? it.server_side_rendering == 0}}
     <script type="text/javascript" src="{{=it.assets}}/magnific-popup/dist/jquery.magnific-popup.min.js?v={{=it.version}}"></script>

--- a/templates/bootstrap2/file.html
+++ b/templates/bootstrap2/file.html
@@ -15,7 +15,6 @@
     <title>{{=it.title}}</title>
 
     <script type="text/javascript" src="{{=it.assets}}/jquery/dist/jquery.min.js?v={{=it.version}}"></script>
-    <script type="text/javascript" src="{{=it.assets}}/js-cookie/dist/js.cookie.js?v={{=it.version}}"></script>
     <script type="text/javascript" src="{{=it.resources}}/simonpioli/sortelements/jquery.sortElements.js?v={{=it.version}}"></script>
 {{? it.server_side_rendering == 0}}
     <script type="text/javascript" src="{{=it.assets}}/magnific-popup/dist/jquery.magnific-popup.min.js?v={{=it.version}}"></script>

--- a/templates/bootstrap5/file.html
+++ b/templates/bootstrap5/file.html
@@ -15,7 +15,6 @@
     <title>{{=it.title}}</title>
 
     <script type="text/javascript" src="{{=it.assets}}/jquery/dist/jquery.min.js?v={{=it.version}}"></script>
-    <script type="text/javascript" src="{{=it.assets}}/js-cookie/dist/js.cookie.js?v={{=it.version}}"></script>
     <script type="text/javascript" src="{{=it.resources}}/simonpioli/sortelements/jquery.sortElements.js?v={{=it.version}}"></script>
 {{? it.server_side_rendering == 0}}
     <script type="text/javascript" src="{{=it.assets}}/magnific-popup/dist/jquery.magnific-popup.min.js?v={{=it.version}}"></script>

--- a/templates/default/file.html
+++ b/templates/default/file.html
@@ -15,7 +15,6 @@
     <title>{{=it.title}}</title>
 
     <script type="text/javascript" src="{{=it.assets}}/jquery/dist/jquery.min.js?v={{=it.version}}"></script>
-    <script type="text/javascript" src="{{=it.assets}}/js-cookie/dist/js.cookie.js?v={{=it.version}}"></script>
     <script type="text/javascript" src="{{=it.resources}}/simonpioli/sortelements/jquery.sortElements.js?v={{=it.version}}"></script>
 {{? it.server_side_rendering == 0}}
     <script type="text/javascript" src="{{=it.assets}}/magnific-popup/dist/jquery.magnific-popup.min.js?v={{=it.version}}"></script>

--- a/templates/twigged/index.html
+++ b/templates/twigged/index.html
@@ -15,7 +15,6 @@
     <title>{{it.title}}</title>
 
     <script type="text/javascript" src="{{asset('jquery/dist/jquery.min.js')}}"></script>
-    <script type="text/javascript" src="{{asset('js-cookie/dist/js.cookie.js')}}"></script>
     <script type="text/javascript" src="{{it.resources}}/simonpioli/sortelements/jquery.sortElements.js?v={{it.version}}"></script>
 {% if it.server_side_rendering == 0 %}
     <script type="text/javascript" src="{{asset('magnific-popup/dist/jquery.magnific-popup.min.js')}}"></script>

--- a/util.js
+++ b/util.js
@@ -59,46 +59,73 @@ function debug_log(text) {
 }
 
 /*exported updateCookie */
-function updateCookie (id) {
-    if ($(id).prop('pattern') && !$(id).val().match(new RegExp ($(id).prop('pattern')))) {
+function updateCookie(id) {
+    var pattern = $(id).prop('pattern');
+    var value = $(id).val();
+
+    // Validate input against pattern, if one is present
+    if (pattern && !value.match(new RegExp(pattern))) {
         return;
     }
+
     var name = $(id).attr('id');
-    var value = $(id).val ();
-    Cookies.set(name, value, { expires: 365 });
+
+    // Calculate the expiration date (365 days from now)
+    var d = new Date();
+    d.setTime(d.getTime() + (365 * 24 * 60 * 60 * 1000));
+    var expires = "expires=" + d.toUTCString();
+
+    // Set the cookie manually
+    document.cookie = name + "=" + encodeURIComponent(value) + ";" + expires + ";path=/";
 }
 
 /*exported updateCookieFromCheckbox */
-function updateCookieFromCheckbox (id) {
+function updateCookieFromCheckbox(id) {
+   // rewritten by ChatGPT to avoid js-cookie
     var name = $(id).attr('id');
-    if (name.indexOf('-') !== -1) { // Replaced includes with indexOf
+
+    // Fallback from String.includes() to indexOf for compatibility
+    if (name.indexOf('-') !== -1) {
         var nameArray = name.split('-');
         name = nameArray[0];
     }
-    if ($(id).is(":checked"))
-    {
+
+    if ($(id).is(":checked")) {
+        var value;
         if ($(id).is(':radio')) {
-            Cookies.set(name, $(id).val (), { expires: 365 });
+            value = $(id).val();
         } else {
-            Cookies.set(name, '1', { expires: 365 });
+            value = '1';
         }
-    }
-    else
-    {
-        Cookies.set(name, '0', { expires: 365 });
+        // Set cookie to expire in 365 days
+        var d = new Date();
+        d.setTime(d.getTime() + (365 * 24 * 60 * 60 * 1000));
+        var expires = "expires=" + d.toUTCString();
+        // Set the cookie manually using document.cookie
+        document.cookie = name + "=" + encodeURIComponent(value) + ";" + expires + ";path=/";
     }
 }
 
 /*exported updateCookieFromCheckboxGroup */
-function updateCookieFromCheckboxGroup (id) {
+function updateCookieFromCheckboxGroup(id) {
     var name = $(id).attr('name');
-    var idBase = name.replace (/\[\]/, "");
+    var idBase = name.replace(/\[\]/, "");
     var group = [];
-    $(':checkbox[name="' + name + '"]:checked').each (function () {
-        var id = $(this).attr("id");
-        group.push (id.replace (idBase + "_", ""));
+
+    $(':checkbox[name="' + name + '"]:checked').each(function () {
+        var checkboxId = $(this).attr("id");
+        group.push(checkboxId.replace(idBase + "_", ""));
     });
-    Cookies.set(idBase, group.join (), { expires: 365 });
+
+    var value = group.join();
+
+    // Set cookie to expire in 365 days
+    var d = new Date();
+    d.setTime(d.getTime() + (365 * 24 * 60 * 60 * 1000));
+    var expires = "expires=" + d.toUTCString();
+
+    // Set the cookie manually
+    document.cookie = idBase + "=" + encodeURIComponent(value) + ";" + expires + ";path=/";
 }
 
 


### PR DESCRIPTION
Remove requirement for js-cookie by rewriting cookie functions in util.js.  Also removes links to js-cookie from template files and also removes js-cookie from composer.json as it is no longer needed anywhere.