### PR TITLE
Longer cookies

### DIFF
--- a/util.js
+++ b/util.js
@@ -516,7 +516,7 @@ function handleLinks () {
     $("body").on ("click", ".headright", function(){
         if ($("#tool").is(":hidden")) {
             $("#tool").slideDown("slow");
-            Cookies.get('toolbar', '1', { expires: 365 });
+            Cookies.get('toolbar', '1');
         } else {
             $("#tool").slideUp();
             Cookies.remove('toolbar');

--- a/util.js
+++ b/util.js
@@ -9,6 +9,8 @@ var templatePage, templateBookDetail, templateMain, templateSuggestion, currentD
 
 var CLEAR_FILTER_ID = "_CLEAR_";
 
+var COOKIE_LIFETIME = 400; // Set the maximum time cookies should be stored in days - most browsers now limit this to 400 days
+
 if (typeof LRUCache === 'undefined') {
     console.log('ERROR: LRUCache module not loaded!');
 }
@@ -65,7 +67,7 @@ function updateCookie (id) {
     }
     var name = $(id).attr('id');
     var value = $(id).val ();
-    Cookies.set(name, value, { expires: 365 });
+    Cookies.set(name, value, { expires: COOKIE_LIFETIME });
 }
 
 /*exported updateCookieFromCheckbox */
@@ -78,14 +80,14 @@ function updateCookieFromCheckbox (id) {
     if ($(id).is(":checked"))
     {
         if ($(id).is(':radio')) {
-            Cookies.set(name, $(id).val (), { expires: 365 });
+            Cookies.set(name, $(id).val (), { expires: COOKIE_LIFETIME });
         } else {
-            Cookies.set(name, '1', { expires: 365 });
+            Cookies.set(name, '1', { expires: COOKIE_LIFETIME });
         }
     }
     else
     {
-        Cookies.set(name, '0', { expires: 365 });
+        Cookies.set(name, '0', { expires: COOKIE_LIFETIME });
     }
 }
 
@@ -98,7 +100,7 @@ function updateCookieFromCheckboxGroup (id) {
         var id = $(this).attr("id");
         group.push (id.replace (idBase + "_", ""));
     });
-    Cookies.set(idBase, group.join (), { expires: 365 });
+    Cookies.set(idBase, group.join (), { expires: COOKIE_LIFETIME });
 }
 
 
@@ -134,7 +136,7 @@ function sendToMailAddress (component, dataid) {
         {
             return;
         }
-        Cookies.set('email', email, { expires: 365 });
+        Cookies.set('email', email, { expires: COOKIE_LIFETIME });
     }
     var url = currentData.baseurl + '/mail';
     if (currentData.databaseId) {


### PR DESCRIPTION
Modern browsers often have a limit on how long a cookie can be stored.  Typically this is 400 days although I have observed shorter in Brave and Safari (7 days for JS set cookies).  Currently util.js sets the cookie expires date to 365 days in the future.  This is probably why I lost the template settings and I then noticed the issue described in #140 after 365 days had passed.  

Anyway, I thought we may as well set this higher, so I added a variable at the top of util.js where the desired length can be entered once, which is used everywhere util.js sets cookies.  I set this to 400, but it may be possible to set this even higher as browsers may cap it to their maximum anyway.  Older browsers such as Kindle Experimental Web Browser may not apply this cap - Chrome only stared doing it in 2022, and those may be the browsers where expiring the cookies results in the most problems.

I also noticed one call to Cookies.get was specifying the expires value, which is incorrect so I removed this.